### PR TITLE
Implement section highlight with lookup from AppStore

### DIFF
--- a/client/src/components/SectionTable/SectionTableBody.js
+++ b/client/src/components/SectionTable/SectionTableBody.js
@@ -227,12 +227,7 @@ const InstructorsCell = withStyles(styles)((props) => {
             if (profName !== 'STAFF') {
                 return (
                     <CustomTooltip interactive placement="left" title={<DualButton profName={profName} />}>
-                        <div
-                            style={{ display: 'block' }}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className={classes.link}
-                        >
+                        <div style={{ display: 'block' }} rel="noopener noreferrer" className={classes.link}>
                             {profName}
                         </div>
                     </CustomTooltip>
@@ -399,7 +394,7 @@ const SectionTableBody = withStyles(styles)((props) => {
     }, []);
 
     return (
-        <tr className={classNames(classes.tr, { addedCourse: addedCourse })}>
+        <tr className={classNames(classes.tr, { addedCourse: addedCourse && !colorAndDelete })}>
             {!colorAndDelete ? (
                 <ScheduleAddCell section={section} courseDetails={courseDetails} term={term} />
             ) : (

--- a/client/src/components/SectionTable/SectionTableBody.js
+++ b/client/src/components/SectionTable/SectionTableBody.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import locations from './static/locations';
 import restrictionsMapping from './static/restrictionsMapping';
 import RMPData from './static/RMP';
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import { addCourse, openSnackbar } from '../../actions/AppStoreActions';
 import AppStore from '../../stores/AppStore';
 import ColorAndDelete from '../AddedCourses/ColorAndDelete';
+import classNames from 'classnames';
 
 const styles = (theme) => ({
     popover: {
@@ -57,6 +58,9 @@ const styles = (theme) => ({
             // border: '1px solid rgb(222, 226, 230)',
             textAlign: 'left',
             verticalAlign: 'top',
+        },
+        '&.addedCourse': {
+            backgroundColor: '#fcfc97',
         },
     },
     open: {
@@ -375,9 +379,27 @@ const StatusCell = withStyles(styles)((props) => {
 //TODO: SectionNum name parity -> SectionNumber
 const SectionTableBody = withStyles(styles)((props) => {
     const { classes, section, courseDetails, term, colorAndDelete } = props;
+    const [addedCourse, setAddedCourse] = useState(false);
+
+    const toggleHighlight = () => {
+        if (AppStore.getAddedSectionCodes()[AppStore.getCurrentScheduleIndex()].has(section.sectionCode))
+            setAddedCourse(true);
+        else setAddedCourse(false);
+    };
+
+    useEffect(() => {
+        toggleHighlight();
+        AppStore.on('addedCoursesChange', toggleHighlight);
+        AppStore.on('currentScheduleIndexChange', toggleHighlight);
+
+        return () => {
+            AppStore.removeListener('addedCoursesChange', toggleHighlight);
+            AppStore.removeListener('currentScheduleIndexChange', toggleHighlight);
+        };
+    }, []);
 
     return (
-        <tr className={classes.tr}>
+        <tr className={classNames(classes.tr, { addedCourse: addedCourse })}>
             {!colorAndDelete ? (
                 <ScheduleAddCell section={section} courseDetails={courseDetails} term={term} />
             ) : (

--- a/client/src/stores/AppStore.js
+++ b/client/src/stores/AppStore.js
@@ -9,6 +9,7 @@ class AppStore extends EventEmitter {
         this.currentScheduleIndex = 0;
         this.customEvents = [];
         this.addedCourses = [];
+        this.addedSectionCodes = { 0: new Set(), 1: new Set(), 2: new Set(), 3: new Set() };
         this.deletedCourses = [];
         this.snackbarMessage = '';
         this.snackbarVariant = 'info';
@@ -74,14 +75,28 @@ class AppStore extends EventEmitter {
         return this.darkMode;
     }
 
+    getAddedSectionCodes() {
+        return this.addedSectionCodes;
+    }
+
     hasUnsavedChanges() {
         return this.unsavedChanges;
+    }
+
+    updateAddedSectionCodes() {
+        this.addedSectionCodes = { 0: new Set(), 1: new Set(), 2: new Set(), 3: new Set() };
+        for (const course of this.addedCourses) {
+            for (const scheduleIndex of course.scheduleIndices) {
+                this.addedSectionCodes[scheduleIndex].add(course.section.sectionCode);
+            }
+        }
     }
 
     handleActions(action) {
         switch (action.type) {
             case 'ADD_COURSE':
                 this.addedCourses = this.addedCourses.concat(action.newCourse);
+                this.updateAddedSectionCodes();
                 this.finalsEventsInCalendar = calendarizeFinals();
                 this.eventsInCalendar = calendarizeCourseEvents().concat(calendarizeCustomEvents());
                 this.unsavedChanges = true;
@@ -92,6 +107,7 @@ class AppStore extends EventEmitter {
                     if (course.section.sectionCode === action.newSection.section.sectionCode) return action.newSection;
                     else return course;
                 });
+                this.updateAddedSectionCodes();
                 this.finalsEventsInCalendar = calendarizeFinals();
                 this.eventsInCalendar = calendarizeCourseEvents().concat(calendarizeCustomEvents());
                 this.unsavedChanges = true;
@@ -99,6 +115,7 @@ class AppStore extends EventEmitter {
                 break;
             case 'DELETE_COURSE':
                 this.addedCourses = action.addedCoursesAfterDelete;
+                this.updateAddedSectionCodes();
                 this.deletedCourses = action.deletedCourses;
                 this.finalsEventsInCalendar = calendarizeFinals();
                 this.eventsInCalendar = calendarizeCourseEvents().concat(calendarizeCustomEvents());
@@ -115,6 +132,7 @@ class AppStore extends EventEmitter {
                 break;
             case 'CLEAR_SCHEDULE':
                 this.addedCourses = action.addedCoursesAfterClear;
+                this.updateAddedSectionCodes();
                 this.customEvents = action.customEventsAfterClear;
                 this.finalsEventsInCalendar = calendarizeFinals();
                 this.eventsInCalendar = calendarizeCourseEvents().concat(calendarizeCustomEvents());
@@ -138,6 +156,7 @@ class AppStore extends EventEmitter {
                 break;
             case 'COURSE_COLOR_CHANGE':
                 this.addedCourses = action.addedCoursesAfterColorChange;
+                this.updateAddedSectionCodes();
                 this.finalsEventsInCalendar = calendarizeFinals();
                 this.eventsInCalendar = calendarizeCourseEvents().concat(calendarizeCustomEvents());
                 this.unsavedChanges = true;
@@ -152,6 +171,7 @@ class AppStore extends EventEmitter {
                 break;
             case 'LOAD_SCHEDULE':
                 this.addedCourses = action.userData.addedCourses;
+                this.updateAddedSectionCodes();
                 this.customEvents = action.userData.customEvents;
                 this.finalsEventsInCalendar = calendarizeFinals();
                 this.eventsInCalendar = calendarizeCourseEvents().concat(calendarizeCustomEvents());
@@ -178,6 +198,7 @@ class AppStore extends EventEmitter {
                 break;
             case 'COPY_SCHEDULE':
                 this.addedCourses = action.addedCoursesAfterCopy;
+                this.updateAddedSectionCodes();
                 this.customEvents = action.customEventsAfterCopy;
                 this.finalsEventsInCalendar = calendarizeFinals();
                 this.eventsInCalendar = calendarizeCourseEvents().concat(calendarizeCustomEvents());


### PR DESCRIPTION
**Summary**
This is an alternative solution to #26 . The `SectionTableBody` looks into a new field in the AppStore called `addedSectionCodes`, which maps schedule indices to section codes. This field stays in sync with addedCourses. The `SectionTableComponent` listens to changes to `addedCourses`  and `currentScheduleIndex` to decide whether to apply a highlight to the row or not. A highlight is applied if the current schedule in view contains a course with the same section code.

**Test Plan**
- Verify that clicking add highlights the corresponding row
- Verify that deleting a course from the schedule removes the highlight
- Verify that all courses are highlighted in the Added Classes tab
- Verify that switching schedule numbers highlights only the corresponding courses
- Verify that doing a new search retains highlights

**Issues**
#26 