### PR TITLE
Fix added courses desync bug, Address performance issues in CourseRenderPane

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,6 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@john-osullivan/react-window-dynamic-fork": "^1.9.0-alpha.1",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",
         "@material-ui/lab": "^4.0.0-alpha.56",
@@ -22,9 +21,9 @@
         "react-dom": "^16.13.1",
         "react-ga": "^2.7.0",
         "react-input-mask": "^2.0.4",
+        "react-lazyload": "^3.1.0",
         "react-leaflet": "^2.7.0",
         "react-scripts": "^3.4.1",
-        "react-virtualized-auto-sizer": "^1.0.2",
         "recharts": "^1.8.5"
     },
     "scripts": {

--- a/client/src/components/AddedCourses/AddedCoursePane.js
+++ b/client/src/components/AddedCourses/AddedCoursePane.js
@@ -65,6 +65,7 @@ class AddedCoursePane extends PureComponent {
                     });
                 } else {
                     formattedCourse = {
+                        term: addedCourse.term,
                         deptCode: addedCourse.deptCode,
                         courseComment: addedCourse.courseComment,
                         prerequisiteLink: addedCourse.prerequisiteLink,
@@ -104,9 +105,9 @@ class AddedCoursePane extends PureComponent {
                     </Typography>
 
                     <div>
-                        <PopupState variant="popover" popupId="demo-popup-menu">
+                        <PopupState variant="popover">
                             {(popupState) => (
-                                <React.Fragment>
+                                <Fragment>
                                     <Button variant="outlined" color="primary" {...bindTrigger(popupState)}>
                                         Copy Schedule
                                     </Button>
@@ -114,6 +115,7 @@ class AddedCoursePane extends PureComponent {
                                         {[0, 1, 2, 3].map((index) => {
                                             return (
                                                 <MenuItem
+                                                    key={index}
                                                     disabled={AppStore.getCurrentScheduleIndex() === index}
                                                     onClick={() => {
                                                         copySchedule(AppStore.getCurrentScheduleIndex(), index);
@@ -133,7 +135,7 @@ class AddedCoursePane extends PureComponent {
                                             Copy to All Schedules
                                         </MenuItem>
                                     </Menu>
-                                </React.Fragment>
+                                </Fragment>
                             )}
                         </PopupState>
                         <Button
@@ -181,7 +183,7 @@ class AddedCoursePane extends PureComponent {
     render() {
         return (
             <div>
-                <Grid container spacing={16}>
+                <Grid container spacing={2}>
                     {this.getGrid()}
                 </Grid>
             </div>

--- a/client/src/components/AddedCourses/ColorAndDelete.js
+++ b/client/src/components/AddedCourses/ColorAndDelete.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import ColorPicker from '../App/ColorPicker';
 import { IconButton } from '@material-ui/core';
 import { deleteCourse } from '../../actions/AppStoreActions';
@@ -24,14 +24,14 @@ const styles = {
 const ColorAndDelete = (props) => {
     const { sectionCode, color, classes } = props;
     return (
-        <Fragment>
+        <td>
             <div className={classes.colorPicker}>
                 <ColorPicker color={color} isCustomEvent={false} sectionCode={sectionCode} />
             </div>
             <IconButton onClick={() => deleteCourse(sectionCode, AppStore.getCurrentScheduleIndex())}>
                 <Delete fontSize="small" />
             </IconButton>
-        </Fragment>
+        </td>
     );
 };
 

--- a/client/src/components/SectionTable/GEDataFetchProvider.js
+++ b/client/src/components/SectionTable/GEDataFetchProvider.js
@@ -1,0 +1,45 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import SectionTable from './SectionTable';
+import RightPaneStore from '../../stores/RightPaneStore';
+
+class GeDataFetchProvider extends PureComponent {
+    state = {
+        courseDetails: this.props.courseDetails,
+    };
+
+    async componentDidMount() {
+        const formData = RightPaneStore.getFormData();
+
+        const params = {
+            department: this.props.courseDetails.deptCode,
+            term: formData.term,
+            ge: 'ANY',
+            courseNumber: this.props.courseDetails.courseNumber,
+        };
+
+        const response = await fetch('/api/websocapi', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(params),
+        });
+
+        const jsonResp = await response.json();
+
+        this.setState({
+            courseDetails: jsonResp.schools[0].departments[0].courses[0],
+        });
+    }
+
+    render() {
+        return <SectionTable {...this.props} courseDetails={this.state.courseDetails} />;
+    }
+}
+
+GeDataFetchProvider.propTypes = {
+    courseDetails: PropTypes.object.isRequired,
+    term: PropTypes.string.isRequired,
+    colorAndDelete: PropTypes.bool.isRequired,
+};
+
+export default GeDataFetchProvider;

--- a/client/src/components/SectionTable/SectionTable.js
+++ b/client/src/components/SectionTable/SectionTable.js
@@ -5,7 +5,6 @@ import AlmanacGraph from '../EnrollmentGraph/EnrollmentGraph';
 import CourseInfoBar from './CourseInfoBar';
 import SectionTableBody from './SectionTableBody';
 import PropTypes from 'prop-types';
-import RightPaneStore from '../../stores/RightPaneStore';
 
 const styles = {
     table: {
@@ -42,38 +41,8 @@ const styles = {
 };
 
 class SectionTable extends PureComponent {
-    //TODO: for efficiency, search multiple classes at once
-    state = {
-        courseDetails: this.props.courseDetails,
-    };
-
-    async componentDidMount() {
-        const formData = RightPaneStore.getFormData();
-
-        if (formData.ge !== 'ANY') {
-            const params = {
-                department: this.props.courseDetails.deptCode,
-                term: formData.term,
-                ge: 'ANY',
-                courseNumber: this.props.courseDetails.courseNumber,
-            };
-
-            const response = await fetch('/api/websocapi', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(params),
-            });
-
-            const jsonResp = await response.json();
-
-            this.setState({
-                courseDetails: jsonResp.schools[0].departments[0].courses[0],
-            });
-        }
-    }
-
     render() {
-        const { classes, term } = this.props;
+        const { classes } = this.props;
 
         return (
             <Fragment>
@@ -83,14 +52,14 @@ class SectionTable extends PureComponent {
                     }}
                 >
                     <CourseInfoBar
-                        deptCode={this.state.courseDetails.deptCode}
-                        courseTitle={this.state.courseDetails.courseTitle}
-                        courseNumber={this.state.courseDetails.courseNumber}
+                        deptCode={this.props.courseDetails.deptCode}
+                        courseTitle={this.props.courseDetails.courseTitle}
+                        courseNumber={this.props.courseDetails.courseNumber}
                     />
 
-                    <AlmanacGraph courseDetails={this.state.courseDetails} />
+                    <AlmanacGraph courseDetails={this.props.courseDetails} />
 
-                    {this.state.courseDetails.prerequisiteLink ? (
+                    {this.props.courseDetails.prerequisiteLink ? (
                         <Typography variant="h6" style={{ flexGrow: '2', marginTop: 9 }}>
                             <a
                                 target="blank"
@@ -98,7 +67,7 @@ class SectionTable extends PureComponent {
                                     textDecoration: 'none',
                                     color: '#72a9ed',
                                 }}
-                                href={this.state.courseDetails.prerequisiteLink}
+                                href={this.props.courseDetails.prerequisiteLink}
                                 rel="noopener noreferrer"
                             >
                                 Prerequisites
@@ -123,12 +92,13 @@ class SectionTable extends PureComponent {
                         </tr>
                     </thead>
                     <tbody>
-                        {this.state.courseDetails.sections.map((section) => {
+                        {this.props.courseDetails.sections.map((section) => {
                             return (
                                 <SectionTableBody
+                                    key={section.sectionCode}
                                     section={section}
-                                    courseDetails={this.state.courseDetails}
-                                    term={term}
+                                    courseDetails={this.props.courseDetails}
+                                    term={this.props.term}
                                     colorAndDelete={this.props.colorAndDelete}
                                 />
                             );

--- a/client/src/components/SectionTable/SectionTableBody.js
+++ b/client/src/components/SectionTable/SectionTableBody.js
@@ -222,15 +222,13 @@ const InstructorsCell = withStyles(styles)((props) => {
         return professorNames.map((profName) => {
             if (profName !== 'STAFF') {
                 return (
-                    <CustomTooltip interactive placement="left" title={<DualButton profName={profName} />}>
-                        <div
-                            style={{ display: 'block' }}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className={classes.link}
-                        >
-                            {profName}
-                        </div>
+                    <CustomTooltip
+                        key={profName}
+                        interactive
+                        placement="left"
+                        title={<DualButton profName={profName} />}
+                    >
+                        <div className={classes.link}>{profName}</div>
                     </CustomTooltip>
                 );
             } else {
@@ -249,7 +247,7 @@ const LocationsCell = withStyles(styles)((props) => {
         <td className={classes.multiline}>
             {meetings.map((meeting) => {
                 return meeting.bldg !== 'TBA' ? (
-                    <Fragment>
+                    <Fragment key={meeting.bldg}>
                         <a
                             href={(() => {
                                 const location_id = locations[meeting.bldg.split(' ')[0]];


### PR DESCRIPTION
**Summary**
The issue with the added courses desyncing was caused by SectionTable (used by AddedCoursePane), which took a prop `courseDetails` and copied it to its state to render the data. The state copying was implemented as a little trick to enable each individual SectionTable to perform an AJAX fetch to the websoc API to collect co-course data when a GE search was performed. SectionTable would perform the request and update its state instead of relying on the prop to render the information in this case.

Here, when courses were deleted and the SectionTable had to be updated, the updates would come down as props from AddedCoursePane. Since SectionTable relied on its state to render the data, it wouldn't recognize the changes and therefore would not update to reflect the changes, unless unmounted and remounted. SectionTable only copied the prop to state on first mount/render.

I fixed this by moving the fetch logic out of SectionTable and creating an HOC, GEDataFetchProvider, to wrap SectionTable when needed for the GE searches. SectionTable now only uses the prop to render information.

As I was messing around with CourseRenderPane while working on this, I decided to remove the alpha fork of react-window we used, and replaced it with a library I found, [react-lazyload](https://github.com/twobin/react-lazyload). This library doesn't perform full virtualization of components (which we don't need) and enables fast rendering of the search results when performing a search.  
It is relatively lightweight, and all it does is defer rendering of SectionTables until they are about to come into view. After they are rendered, it forgets about them (doesn't do virtualization). This cuts overhead and improves scroll performance. 

**Known Issues**
On Firefox, once you scroll in the search area, your scroll position is kept for future searches and even if you refresh the page. It's very odd and related to this obscure [browser bug](https://bugzilla.mozilla.org/show_bug.cgi?id=706792).

**Test Plan**
Changes for #21 
- Renders faster/as fast as react-window version
- GE searches render co courses when scrolled to, not all at once
- Displays all SectionTables and School/Department headers

Changes for #46 
- Clear schedule and deleting courses from added courses work properly
- Clear schedule and deleting courses from schedule work properly
- Undo delete restores courses into added courses
- Removing all sections under a course removes the whole course
- Added courses show up in added courses

**Issues**
#21 
#46 